### PR TITLE
Support names with spaces in /impersonate command

### DIFF
--- a/chat/command.go
+++ b/chat/command.go
@@ -538,14 +538,14 @@ func InitCommands(c *Commands) {
 				return errors.New("must be op")
 			}
 
-			re := regexp.MustCompile("^/impersonate (\\S+) (.*)$")
+			re := regexp.MustCompile("^/impersonate (?:\"([^\"]+)\"|(\\S+)) (.*)$")
 			match := re.FindStringSubmatch(msg.Body())
 			if match == nil {
 				return errors.New("must specify user and text")
 			}
 
-			user := message.NewUserDeterministic(message.SimpleID(match[1]))
-			room.Send(message.NewPublicMsg(match[2], user))
+			user := message.NewUserDeterministic(message.SimpleID(match[1] + match[2]))
+			room.Send(message.NewPublicMsg(match[3], user))
 
 			return nil
 		},


### PR DESCRIPTION
Usecase:

```
/impersonate username message...
/impersonate "username" message...
```

The second usecase supports spaces in username.

![image](https://user-images.githubusercontent.com/16370781/147601295-cf740d3f-ea42-4c63-a7e7-c2a6dea146a6.png)
